### PR TITLE
Fixed a simple typo for 'Connection type' label

### DIFF
--- a/src/main/java/com/idea/tools/view/components/ServerEditMainPanel.form
+++ b/src/main/java/com/idea/tools/view/components/ServerEditMainPanel.form
@@ -31,7 +31,7 @@
           <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Connenction type"/>
+          <text value="Connection type"/>
         </properties>
       </component>
       <component id="5997b" class="javax.swing.JComboBox" binding="connectionType" custom-create="true">


### PR DESCRIPTION
Thanks for the plugin!

Fixed a simple typo for 'Connection type' label.